### PR TITLE
Racetracks views complete with admin only access for create and edit

### DIFF
--- a/FairWeatherFriend/Controllers/RaceTracksController.cs
+++ b/FairWeatherFriend/Controllers/RaceTracksController.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using FairWeatherFriend.Data;
+using FairWeatherFriend.Models;
+
+namespace FairWeatherFriend.Controllers
+{
+    public class RaceTracksController : Controller
+    {
+        private readonly ApplicationDbContext _context;
+
+        public RaceTracksController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        // GET: RaceTracks
+        public async Task<IActionResult> Index()
+        {
+            return View(await _context.RaceTrack.ToListAsync());
+        }
+
+        // GET: RaceTracks/Details/5
+        public async Task<IActionResult> Details(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var raceTrack = await _context.RaceTrack.Include(r => r.Races)
+                .FirstOrDefaultAsync(m => m.Id == id);
+            if (raceTrack == null)
+            {
+                return NotFound();
+            }
+
+            return View(raceTrack);
+        }
+
+        // GET: RaceTracks/Create
+        public IActionResult Create()
+        {
+            return View();
+        }
+
+        // POST: RaceTracks/Create
+        // To protect from overposting attacks, please enable the specific properties you want to bind to, for 
+        // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create([Bind("Id,Location,Name,ZipCode")] RaceTrack raceTrack)
+        {
+            if (ModelState.IsValid)
+            {
+                _context.Add(raceTrack);
+                await _context.SaveChangesAsync();
+                return RedirectToAction(nameof(Index));
+            }
+            return View(raceTrack);
+        }
+
+        // GET: RaceTracks/Edit/5
+        public async Task<IActionResult> Edit(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var raceTrack = await _context.RaceTrack.FindAsync(id);
+            if (raceTrack == null)
+            {
+                return NotFound();
+            }
+            return View(raceTrack);
+        }
+
+        // POST: RaceTracks/Edit/5
+        // To protect from overposting attacks, please enable the specific properties you want to bind to, for 
+        // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit(int id, [Bind("Id,Location,Name,ZipCode")] RaceTrack raceTrack)
+        {
+            if (id != raceTrack.Id)
+            {
+                return NotFound();
+            }
+
+            if (ModelState.IsValid)
+            {
+                try
+                {
+                    _context.Update(raceTrack);
+                    await _context.SaveChangesAsync();
+                }
+                catch (DbUpdateConcurrencyException)
+                {
+                    if (!RaceTrackExists(raceTrack.Id))
+                    {
+                        return NotFound();
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+                return RedirectToAction(nameof(Index));
+            }
+            return View(raceTrack);
+        }
+
+        // GET: RaceTracks/Delete/5
+        public async Task<IActionResult> Delete(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var raceTrack = await _context.RaceTrack
+                .FirstOrDefaultAsync(m => m.Id == id);
+            if (raceTrack == null)
+            {
+                return NotFound();
+            }
+
+            return View(raceTrack);
+        }
+
+        // POST: RaceTracks/Delete/5
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirmed(int id)
+        {
+            var raceTrack = await _context.RaceTrack.FindAsync(id);
+            _context.RaceTrack.Remove(raceTrack);
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(Index));
+        }
+
+        private bool RaceTrackExists(int id)
+        {
+            return _context.RaceTrack.Any(e => e.Id == id);
+        }
+    }
+}

--- a/FairWeatherFriend/Controllers/RacesController.cs
+++ b/FairWeatherFriend/Controllers/RacesController.cs
@@ -57,7 +57,7 @@ namespace FairWeatherFriend.Controllers
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create([Bind("Id,TimeOfDay,isCancelled,Prize,RaceTrackId")] Race race)
+        public async Task<IActionResult> Create([Bind("Id,TimeOfDay,isCancelled,Prize,RaceTrackId,Name,Laps")] Race race)
         {
             if (ModelState.IsValid)
             {
@@ -91,7 +91,7 @@ namespace FairWeatherFriend.Controllers
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(int id, [Bind("Id,TimeOfDay,isCancelled,Prize,RaceTrackId")] Race race)
+        public async Task<IActionResult> Edit(int id, [Bind("Id,TimeOfDay,isCancelled,Prize,RaceTrackId,Name,Laps")] Race race)
         {
             if (id != race.Id)
             {

--- a/FairWeatherFriend/Controllers/RacesController.cs
+++ b/FairWeatherFriend/Controllers/RacesController.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using FairWeatherFriend.Data;
+using FairWeatherFriend.Models;
+
+namespace FairWeatherFriend.Controllers
+{
+    public class RacesController : Controller
+    {
+        private readonly ApplicationDbContext _context;
+
+        public RacesController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        // GET: Races
+        public async Task<IActionResult> Index()
+        {
+            var applicationDbContext = _context.Race.Include(r => r.Track);
+            return View(await applicationDbContext.ToListAsync());
+        }
+
+        // GET: Races/Details/5
+        public async Task<IActionResult> Details(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var race = await _context.Race
+                .Include(r => r.Track)
+                .FirstOrDefaultAsync(m => m.Id == id);
+            if (race == null)
+            {
+                return NotFound();
+            }
+
+            return View(race);
+        }
+
+        // GET: Races/Create
+        public IActionResult Create()
+        {
+            ViewData["RaceTrackId"] = new SelectList(_context.RaceTrack, "Id", "Location");
+            return View();
+        }
+
+        // POST: Races/Create
+        // To protect from overposting attacks, please enable the specific properties you want to bind to, for 
+        // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create([Bind("Id,TimeOfDay,isCancelled,Prize,RaceTrackId")] Race race)
+        {
+            if (ModelState.IsValid)
+            {
+                _context.Add(race);
+                await _context.SaveChangesAsync();
+                return RedirectToAction(nameof(Index));
+            }
+            ViewData["RaceTrackId"] = new SelectList(_context.RaceTrack, "Id", "Location", race.RaceTrackId);
+            return View(race);
+        }
+
+        // GET: Races/Edit/5
+        public async Task<IActionResult> Edit(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var race = await _context.Race.FindAsync(id);
+            if (race == null)
+            {
+                return NotFound();
+            }
+            ViewData["RaceTrackId"] = new SelectList(_context.RaceTrack, "Id", "Location", race.RaceTrackId);
+            return View(race);
+        }
+
+        // POST: Races/Edit/5
+        // To protect from overposting attacks, please enable the specific properties you want to bind to, for 
+        // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit(int id, [Bind("Id,TimeOfDay,isCancelled,Prize,RaceTrackId")] Race race)
+        {
+            if (id != race.Id)
+            {
+                return NotFound();
+            }
+
+            if (ModelState.IsValid)
+            {
+                try
+                {
+                    _context.Update(race);
+                    await _context.SaveChangesAsync();
+                }
+                catch (DbUpdateConcurrencyException)
+                {
+                    if (!RaceExists(race.Id))
+                    {
+                        return NotFound();
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+                return RedirectToAction(nameof(Index));
+            }
+            ViewData["RaceTrackId"] = new SelectList(_context.RaceTrack, "Id", "Location", race.RaceTrackId);
+            return View(race);
+        }
+
+        // GET: Races/Delete/5
+        public async Task<IActionResult> Delete(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var race = await _context.Race
+                .Include(r => r.Track)
+                .FirstOrDefaultAsync(m => m.Id == id);
+            if (race == null)
+            {
+                return NotFound();
+            }
+
+            return View(race);
+        }
+
+        // POST: Races/Delete/5
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirmed(int id)
+        {
+            var race = await _context.Race.FindAsync(id);
+            _context.Race.Remove(race);
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(Index));
+        }
+
+        private bool RaceExists(int id)
+        {
+            return _context.Race.Any(e => e.Id == id);
+        }
+    }
+}

--- a/FairWeatherFriend/Data/ApplicationDbContext.cs
+++ b/FairWeatherFriend/Data/ApplicationDbContext.cs
@@ -15,5 +15,7 @@ namespace FairWeatherFriend.Data
             
     }
         public DbSet<ApplicationUser> ApplicationUsers { get; set; }
+        public DbSet<FairWeatherFriend.Models.RaceTrack> RaceTrack { get; set; }
+        public DbSet<FairWeatherFriend.Models.Race> Race { get; set; }
     }
 }

--- a/FairWeatherFriend/Data/Migrations/20190626191449_addedid-to-models.Designer.cs
+++ b/FairWeatherFriend/Data/Migrations/20190626191449_addedid-to-models.Designer.cs
@@ -4,60 +4,22 @@ using FairWeatherFriend.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace FairWeatherFriend.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190626191449_addedid-to-models")]
+    partial class addedidtomodels
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "2.2.4-servicing-10062")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128)
                 .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
-
-            modelBuilder.Entity("FairWeatherFriend.Models.Race", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
-
-                    b.Property<int>("Prize");
-
-                    b.Property<int>("RaceTrackId");
-
-                    b.Property<DateTime>("TimeOfDay");
-
-                    b.Property<bool>("isCancelled");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("RaceTrackId");
-
-                    b.ToTable("Race");
-                });
-
-            modelBuilder.Entity("FairWeatherFriend.Models.RaceTrack", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
-
-                    b.Property<string>("Location")
-                        .IsRequired();
-
-                    b.Property<string>("Name")
-                        .IsRequired();
-
-                    b.Property<int>("ZipCode");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("RaceTrack");
-                });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
                 {
@@ -238,14 +200,6 @@ namespace FairWeatherFriend.Data.Migrations
                     b.Property<bool>("isAdmin");
 
                     b.HasDiscriminator().HasValue("ApplicationUser");
-                });
-
-            modelBuilder.Entity("FairWeatherFriend.Models.Race", b =>
-                {
-                    b.HasOne("FairWeatherFriend.Models.RaceTrack", "Track")
-                        .WithMany("Races")
-                        .HasForeignKey("RaceTrackId")
-                        .OnDelete(DeleteBehavior.Cascade);
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>

--- a/FairWeatherFriend/Data/Migrations/20190626191449_addedid-to-models.cs
+++ b/FairWeatherFriend/Data/Migrations/20190626191449_addedid-to-models.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace FairWeatherFriend.Data.Migrations
+{
+    public partial class addedidtomodels : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/FairWeatherFriend/Data/Migrations/20190627132711_updated-models.Designer.cs
+++ b/FairWeatherFriend/Data/Migrations/20190627132711_updated-models.Designer.cs
@@ -4,14 +4,16 @@ using FairWeatherFriend.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace FairWeatherFriend.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190627132711_updated-models")]
+    partial class updatedmodels
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FairWeatherFriend/Data/Migrations/20190627132711_updated-models.cs
+++ b/FairWeatherFriend/Data/Migrations/20190627132711_updated-models.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace FairWeatherFriend.Data.Migrations
+{
+    public partial class updatedmodels : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RaceTrack",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
+                    Location = table.Column<string>(nullable: false),
+                    Name = table.Column<string>(nullable: false),
+                    ZipCode = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RaceTrack", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Race",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
+                    TimeOfDay = table.Column<DateTime>(nullable: false),
+                    isCancelled = table.Column<bool>(nullable: false),
+                    Prize = table.Column<int>(nullable: false),
+                    RaceTrackId = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Race", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Race_RaceTrack_RaceTrackId",
+                        column: x => x.RaceTrackId,
+                        principalTable: "RaceTrack",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Race_RaceTrackId",
+                table: "Race",
+                column: "RaceTrackId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Race");
+
+            migrationBuilder.DropTable(
+                name: "RaceTrack");
+        }
+    }
+}

--- a/FairWeatherFriend/Data/Migrations/20190627140906_updated-race-model.Designer.cs
+++ b/FairWeatherFriend/Data/Migrations/20190627140906_updated-race-model.Designer.cs
@@ -4,14 +4,16 @@ using FairWeatherFriend.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace FairWeatherFriend.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190627140906_updated-race-model")]
+    partial class updatedracemodel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -24,8 +26,6 @@ namespace FairWeatherFriend.Data.Migrations
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
                         .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
-
-                    b.Property<int>("Laps");
 
                     b.Property<string>("Name");
 

--- a/FairWeatherFriend/Data/Migrations/20190627140906_updated-race-model.cs
+++ b/FairWeatherFriend/Data/Migrations/20190627140906_updated-race-model.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace FairWeatherFriend.Data.Migrations
+{
+    public partial class updatedracemodel : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Name",
+                table: "Race",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Name",
+                table: "Race");
+        }
+    }
+}

--- a/FairWeatherFriend/Data/Migrations/20190627142020_added-laps-to-races.Designer.cs
+++ b/FairWeatherFriend/Data/Migrations/20190627142020_added-laps-to-races.Designer.cs
@@ -4,14 +4,16 @@ using FairWeatherFriend.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace FairWeatherFriend.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190627142020_added-laps-to-races")]
+    partial class addedlapstoraces
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FairWeatherFriend/Data/Migrations/20190627142020_added-laps-to-races.cs
+++ b/FairWeatherFriend/Data/Migrations/20190627142020_added-laps-to-races.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace FairWeatherFriend.Data.Migrations
+{
+    public partial class addedlapstoraces : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Laps",
+                table: "Race",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Laps",
+                table: "Race");
+        }
+    }
+}

--- a/FairWeatherFriend/Models/Race.cs
+++ b/FairWeatherFriend/Models/Race.cs
@@ -15,6 +15,8 @@ namespace FairWeatherFriend.Models
         [Display(Name = "Cancelled")]
         public bool isCancelled { get; set; }
         public int Prize { get; set; }
+        public string Name { get; set; }
+        public int Laps { get; set; }
         [Required]
         public int RaceTrackId { get; set; }
         public RaceTrack Track { get; set; }

--- a/FairWeatherFriend/Models/Race.cs
+++ b/FairWeatherFriend/Models/Race.cs
@@ -8,8 +8,11 @@ namespace FairWeatherFriend.Models
 {
     public class Race
     {
+        public int Id { get; set; }
         [Required]
+        [Display(Name = "Date")]
         public DateTime TimeOfDay { get; set; }
+        [Display(Name = "Cancelled")]
         public bool isCancelled { get; set; }
         public int Prize { get; set; }
         [Required]

--- a/FairWeatherFriend/Models/RaceTrack.cs
+++ b/FairWeatherFriend/Models/RaceTrack.cs
@@ -8,11 +8,13 @@ namespace FairWeatherFriend.Models
 {
     public class RaceTrack
     {
+        public int Id { get; set; }
         [Required]
         public string Location { get; set; }
         [Required]
         public string Name { get; set; }
         [Required]
         public int ZipCode { get; set; }
+        public List<Race> Races { get; set; } = new List<Race>();
     }
 }

--- a/FairWeatherFriend/Views/RaceTracks/Create.cshtml
+++ b/FairWeatherFriend/Views/RaceTracks/Create.cshtml
@@ -1,0 +1,43 @@
+﻿@model FairWeatherFriend.Models.RaceTrack
+
+@{
+    ViewData["Title"] = "Create";
+}
+
+<h1>Create</h1>
+
+<h4>RaceTrack</h4>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-action="Create">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="form-group">
+                <label asp-for="Name" class="control-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Location" class="control-label"></label>
+                <input asp-for="Location" class="form-control" />
+                <span asp-validation-for="Location" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="ZipCode" class="control-label"></label>
+                <input asp-for="ZipCode" class="form-control" />
+                <span asp-validation-for="ZipCode" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Create" class="btn btn-primary" />
+            </div>
+        </form>
+    </div>
+</div>
+
+<div>
+    <a asp-action="Index">Back to List</a>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/FairWeatherFriend/Views/RaceTracks/Delete.cshtml
+++ b/FairWeatherFriend/Views/RaceTracks/Delete.cshtml
@@ -1,0 +1,39 @@
+﻿@model FairWeatherFriend.Models.RaceTrack
+
+@{
+    ViewData["Title"] = "Delete";
+}
+
+<h1>Delete</h1>
+
+<h3>Are you sure you want to delete this?</h3>
+<div>
+    <h4>RaceTrack</h4>
+    <hr />
+    <dl class="row">
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Location)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Location)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Name)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Name)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.ZipCode)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.ZipCode)
+        </dd>
+    </dl>
+    
+    <form asp-action="Delete">
+        <input type="hidden" asp-for="Id" />
+        <input type="submit" value="Delete" class="btn btn-danger" /> |
+        <a asp-action="Index">Back to List</a>
+    </form>
+</div>

--- a/FairWeatherFriend/Views/RaceTracks/Details.cshtml
+++ b/FairWeatherFriend/Views/RaceTracks/Details.cshtml
@@ -1,0 +1,73 @@
+﻿@model FairWeatherFriend.Models.RaceTrack
+
+@{
+    ViewData["Title"] = "Details";
+}
+
+@using Microsoft.AspNetCore.Identity
+@using FairWeatherFriend.Models
+
+@inject SignInManager<ApplicationUser> SignInManager
+@inject UserManager<ApplicationUser> UserManager
+
+
+<h1>Details</h1>
+
+<div>
+    <h4>RaceTrack</h4>
+    <hr />
+    <dl class="row">
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Location)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Location)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Name)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Name)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.ZipCode)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.ZipCode)
+        </dd>
+    </dl>
+</div>
+<div>
+    <dl>
+        <h5>Upcoming Races</h5>
+        @foreach (Race UpcomingRace in Model.Races)
+        {
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(ModelItem => UpcomingRace.TimeOfDay)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(ModelItem => UpcomingRace.TimeOfDay)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(ModelItem => UpcomingRace.Prize)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(ModelItem => UpcomingRace.Prize)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(ModelItem => UpcomingRace.isCancelled)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(ModelItem => UpcomingRace.isCancelled)
+            </dd>
+        }
+    </dl>
+</div>
+<div>
+    @if (SignInManager.IsSignedIn(User) && @UserManager.GetUserAsync(User).Result.isAdmin == true)
+    {
+        <a asp-action="Edit" asp-route-id="@Model.Id">Edit</a> 
+}
+
+    <a asp-action="Index">Back to List</a>
+</div>

--- a/FairWeatherFriend/Views/RaceTracks/Details.cshtml
+++ b/FairWeatherFriend/Views/RaceTracks/Details.cshtml
@@ -43,6 +43,12 @@
         @foreach (Race UpcomingRace in Model.Races)
         {
             <dt class="col-sm-2">
+                @Html.DisplayNameFor(ModelItem => UpcomingRace.Name)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(ModelItem => UpcomingRace.Name)
+            </dd>
+            <dt class="col-sm-2">
                 @Html.DisplayNameFor(ModelItem => UpcomingRace.TimeOfDay)
             </dt>
             <dd class="col-sm-10">

--- a/FairWeatherFriend/Views/RaceTracks/Edit.cshtml
+++ b/FairWeatherFriend/Views/RaceTracks/Edit.cshtml
@@ -1,0 +1,44 @@
+﻿@model FairWeatherFriend.Models.RaceTrack
+
+@{
+    ViewData["Title"] = "Edit";
+}
+
+<h1>Edit</h1>
+
+<h4>RaceTrack</h4>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-action="Edit">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <input type="hidden" asp-for="Id" />
+            <div class="form-group">
+                <label asp-for="Location" class="control-label"></label>
+                <input asp-for="Location" class="form-control" />
+                <span asp-validation-for="Location" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Name" class="control-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="ZipCode" class="control-label"></label>
+                <input asp-for="ZipCode" class="form-control" />
+                <span asp-validation-for="ZipCode" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Save" class="btn btn-primary" />
+            </div>
+        </form>
+    </div>
+</div>
+
+<div>
+    <a asp-action="Index">Back to List</a>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/FairWeatherFriend/Views/RaceTracks/Index.cshtml
+++ b/FairWeatherFriend/Views/RaceTracks/Index.cshtml
@@ -1,0 +1,62 @@
+﻿@model IEnumerable<FairWeatherFriend.Models.RaceTrack>
+
+@{
+    ViewData["Title"] = "Index";
+}
+
+@using Microsoft.AspNetCore.Identity
+@using FairWeatherFriend.Models
+
+@inject SignInManager<ApplicationUser> SignInManager
+@inject UserManager<ApplicationUser> UserManager
+
+<h1>Index</h1>
+
+@if (SignInManager.IsSignedIn(User) && @UserManager.GetUserAsync(User).Result.isAdmin == true)
+{
+<p>
+    <a asp-action="Create">Create New</a>
+</p>
+}
+
+<table class="table">
+    <thead>
+        <tr>
+
+            <th>
+                @Html.DisplayNameFor(model => model.Name)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Location)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.ZipCode)
+            </th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var item in Model)
+        {
+            <tr>
+
+                <td>
+                    @Html.DisplayFor(modelItem => item.Name)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Location)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.ZipCode)
+                </td>
+                <td>
+                    @if (SignInManager.IsSignedIn(User) && @UserManager.GetUserAsync(User).Result.isAdmin == true)
+                    {
+                        <a asp-action="Edit" asp-route-id="@item.Id">Edit</a>
+                    }
+                    <a asp-action="Details" asp-route-id="@item.Id">Details</a> |
+                </td>
+            </tr>
+        }
+    </tbody>
+</table>

--- a/FairWeatherFriend/Views/Races/Create.cshtml
+++ b/FairWeatherFriend/Views/Races/Create.cshtml
@@ -1,0 +1,47 @@
+﻿@model FairWeatherFriend.Models.Race
+
+@{
+    ViewData["Title"] = "Create";
+}
+
+<h1>Create</h1>
+
+<h4>Race</h4>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-action="Create">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="form-group">
+                <label asp-for="TimeOfDay" class="control-label"></label>
+                <input asp-for="TimeOfDay" class="form-control" />
+                <span asp-validation-for="TimeOfDay" class="text-danger"></span>
+            </div>
+            <div class="form-group form-check">
+                <label class="form-check-label">
+                    <input class="form-check-input" asp-for="isCancelled" /> @Html.DisplayNameFor(model => model.isCancelled)
+                </label>
+            </div>
+            <div class="form-group">
+                <label asp-for="Prize" class="control-label"></label>
+                <input asp-for="Prize" class="form-control" />
+                <span asp-validation-for="Prize" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="RaceTrackId" class="control-label"></label>
+                <select asp-for="RaceTrackId" class ="form-control" asp-items="ViewBag.RaceTrackId"></select>
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Create" class="btn btn-primary" />
+            </div>
+        </form>
+    </div>
+</div>
+
+<div>
+    <a asp-action="Index">Back to List</a>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/FairWeatherFriend/Views/Races/Create.cshtml
+++ b/FairWeatherFriend/Views/Races/Create.cshtml
@@ -13,6 +13,16 @@
         <form asp-action="Create">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-group">
+                <label asp-for="Name" class="control-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Laps" class="control-label"></label>
+                <input asp-for="Laps" class="form-control" />
+                <span asp-validation-for="Laps" class="text-danger"></span>
+            </div>
+            <div class="form-group">
                 <label asp-for="TimeOfDay" class="control-label"></label>
                 <input asp-for="TimeOfDay" class="form-control" />
                 <span asp-validation-for="TimeOfDay" class="text-danger"></span>
@@ -29,7 +39,7 @@
             </div>
             <div class="form-group">
                 <label asp-for="RaceTrackId" class="control-label"></label>
-                <select asp-for="RaceTrackId" class ="form-control" asp-items="ViewBag.RaceTrackId"></select>
+                <select asp-for="RaceTrackId" class="form-control" asp-items="ViewBag.RaceTrackId"></select>
             </div>
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />

--- a/FairWeatherFriend/Views/Races/Delete.cshtml
+++ b/FairWeatherFriend/Views/Races/Delete.cshtml
@@ -1,0 +1,45 @@
+﻿@model FairWeatherFriend.Models.Race
+
+@{
+    ViewData["Title"] = "Delete";
+}
+
+<h1>Delete</h1>
+
+<h3>Are you sure you want to delete this?</h3>
+<div>
+    <h4>Race</h4>
+    <hr />
+    <dl class="row">
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.TimeOfDay)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.TimeOfDay)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.isCancelled)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.isCancelled)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Prize)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Prize)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Track)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Track.Location)
+        </dd class>
+    </dl>
+    
+    <form asp-action="Delete">
+        <input type="hidden" asp-for="Id" />
+        <input type="submit" value="Delete" class="btn btn-danger" /> |
+        <a asp-action="Index">Back to List</a>
+    </form>
+</div>

--- a/FairWeatherFriend/Views/Races/Details.cshtml
+++ b/FairWeatherFriend/Views/Races/Details.cshtml
@@ -1,0 +1,53 @@
+﻿@model FairWeatherFriend.Models.Race
+
+@{
+    ViewData["Title"] = "Details";
+}
+
+<h1>Details</h1>
+
+<div>
+    <h4>Race</h4>
+    <hr />
+    <dl class="row">
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.TimeOfDay)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.TimeOfDay)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Prize)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Prize)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Track)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Track.Location)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.isCancelled)
+        </dt>
+        @if (Model.isCancelled == true)
+        {
+
+            <dd class="col-sm-10">
+                Cancelled
+            </dd>
+        }
+        else
+        {
+            <dd class="col-sm-10">
+                Race still on
+            </dd>
+        }
+
+    </dl>
+</div>
+<div>
+    <a asp-action="Edit" asp-route-id="@Model.Id">Edit</a> |
+    <a asp-action="Index">Back to List</a>
+</div>

--- a/FairWeatherFriend/Views/Races/Details.cshtml
+++ b/FairWeatherFriend/Views/Races/Details.cshtml
@@ -4,6 +4,13 @@
     ViewData["Title"] = "Details";
 }
 
+@using Microsoft.AspNetCore.Identity
+@using FairWeatherFriend.Models
+
+@inject SignInManager<ApplicationUser> SignInManager
+@inject UserManager<ApplicationUser> UserManager
+
+
 <h1>Details</h1>
 
 <div>
@@ -60,6 +67,10 @@
     </dl>
 </div>
 <div>
-    <a asp-action="Edit" asp-route-id="@Model.Id">Edit</a> |
+    @if (SignInManager.IsSignedIn(User) && @UserManager.GetUserAsync(User).Result.isAdmin == true)
+    {
+        <a asp-action="Edit" asp-route-id="@Model.Id">Edit</a>
+    }
+
     <a asp-action="Index">Back to List</a>
 </div>

--- a/FairWeatherFriend/Views/Races/Details.cshtml
+++ b/FairWeatherFriend/Views/Races/Details.cshtml
@@ -11,6 +11,18 @@
     <hr />
     <dl class="row">
         <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Name)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Name)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Laps)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Laps)
+        </dd>
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.TimeOfDay)
         </dt>
         <dd class="col-sm-10">

--- a/FairWeatherFriend/Views/Races/Edit.cshtml
+++ b/FairWeatherFriend/Views/Races/Edit.cshtml
@@ -1,0 +1,49 @@
+﻿@model FairWeatherFriend.Models.Race
+
+@{
+    ViewData["Title"] = "Edit";
+}
+
+<h1>Edit</h1>
+
+<h4>Race</h4>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-action="Edit">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <input type="hidden" asp-for="Id" />
+            <div class="form-group">
+                <label asp-for="TimeOfDay" class="control-label"></label>
+                <input asp-for="TimeOfDay" class="form-control" />
+                <span asp-validation-for="TimeOfDay" class="text-danger"></span>
+            </div>
+            <div class="form-group form-check">
+                <label class="form-check-label">
+                    <input class="form-check-input" asp-for="isCancelled" /> @Html.DisplayNameFor(model => model.isCancelled)
+                </label>
+            </div>
+            <div class="form-group">
+                <label asp-for="Prize" class="control-label"></label>
+                <input asp-for="Prize" class="form-control" />
+                <span asp-validation-for="Prize" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="RaceTrackId" class="control-label"></label>
+                <select asp-for="RaceTrackId" class="form-control" asp-items="ViewBag.RaceTrackId"></select>
+                <span asp-validation-for="RaceTrackId" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Save" class="btn btn-primary" />
+            </div>
+        </form>
+    </div>
+</div>
+
+<div>
+    <a asp-action="Index">Back to List</a>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/FairWeatherFriend/Views/Races/Edit.cshtml
+++ b/FairWeatherFriend/Views/Races/Edit.cshtml
@@ -14,6 +14,16 @@
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="Id" />
             <div class="form-group">
+                <label asp-for="Name" class="control-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Laps" class="control-label"></label>
+                <input asp-for="Laps" class="form-control" />
+                <span asp-validation-for="Laps" class="text-danger"></span>
+            </div>
+            <div class="form-group">
                 <label asp-for="TimeOfDay" class="control-label"></label>
                 <input asp-for="TimeOfDay" class="form-control" />
                 <span asp-validation-for="TimeOfDay" class="text-danger"></span>

--- a/FairWeatherFriend/Views/Races/Index.cshtml
+++ b/FairWeatherFriend/Views/Races/Index.cshtml
@@ -1,0 +1,64 @@
+﻿@model IEnumerable<FairWeatherFriend.Models.Race>
+
+@{
+    ViewData["Title"] = "Index";
+}
+
+<h1>Index</h1>
+
+<p>
+    <a asp-action="Create">Create New</a>
+</p>
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                @Html.DisplayNameFor(model => model.TimeOfDay)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.isCancelled)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Prize)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Track)
+            </th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model) {
+        <tr>
+            <td>
+                @Html.DisplayFor(modelItem => item.TimeOfDay)
+            </td>
+            <td>@Html.DisplayFor(modelItem => item.isCancelled)</td>
+            @*@if (item.isCancelled == true)
+            {
+
+                <dd class="col-sm-10">
+                    Cancelled
+                </dd>
+            }
+            else
+            {
+                <dd class="col-sm-10">
+                    Race still on
+                </dd>
+            }*@
+            <td>
+                @Html.DisplayFor(modelItem => item.Prize)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Track.Name)
+            </td>
+            <td>
+                <a asp-action="Edit" asp-route-id="@item.Id">Edit</a> |
+                <a asp-action="Details" asp-route-id="@item.Id">Details</a> |
+                <a asp-action="Delete" asp-route-id="@item.Id">Delete</a>
+            </td>
+        </tr>
+}
+    </tbody>
+</table>

--- a/FairWeatherFriend/Views/Races/Index.cshtml
+++ b/FairWeatherFriend/Views/Races/Index.cshtml
@@ -4,11 +4,20 @@
     ViewData["Title"] = "Index";
 }
 
+@using Microsoft.AspNetCore.Identity
+@using FairWeatherFriend.Models
+
+@inject SignInManager<ApplicationUser> SignInManager
+@inject UserManager<ApplicationUser> UserManager
+
 <h1>Index</h1>
 
-<p>
-    <a asp-action="Create">Create New</a>
-</p>
+@if (SignInManager.IsSignedIn(User) && @UserManager.GetUserAsync(User).Result.isAdmin == true)
+{
+    <p>
+        <a asp-action="Create">Create New</a>
+    </p>
+}
 <table class="table">
     <thead>
         <tr>
@@ -34,43 +43,55 @@
         </tr>
     </thead>
     <tbody>
-@foreach (var item in Model) {
-        <tr>
-            <td>
-                @Html.DisplayFor(modelItem => item.Name)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Laps)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.TimeOfDay)
-            </td>
-            <td>@Html.DisplayFor(modelItem => item.isCancelled)</td>
-            @*@if (item.isCancelled == true)
+        @foreach (var item in Model)
         {
+            <tr>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Name)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Laps)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.TimeOfDay)
+                </td>
+                <td>@Html.DisplayFor(modelItem => item.isCancelled)</td>
+                @*@if (item.isCancelled == true)
+                    {
 
-            <dd class="col-sm-10">
-                Cancelled
-            </dd>
+                        <dd class="col-sm-10">
+                            Cancelled
+                        </dd>
+                    }
+                    else
+                    {
+                        <dd class="col-sm-10">
+                            Race still on
+                        </dd>
+                    }*@
+                <td>
+                    @Html.DisplayFor(modelItem => item.Prize)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Track.Name)
+                </td>
+                <td>
+                    @if (SignInManager.IsSignedIn(User) && @UserManager.GetUserAsync(User).Result.isAdmin == true)
+                    {
+                        <a asp-action="Edit" asp-route-id="@item.Id">Edit</a>
+
+
+                    }
+                    @if (SignInManager.IsSignedIn(User) && @UserManager.GetUserAsync(User).Result.isAdmin == true)
+                    {
+                        <a asp-action="Delete" asp-route-id="@item.Id">Delete</a>
+                    }
+
+
+
+                    <a asp-action="Details" asp-route-id="@item.Id">Details</a> 
+                </td>
+            </tr>
         }
-        else
-        {
-            <dd class="col-sm-10">
-                Race still on
-            </dd>
-        }*@
-            <td>
-                @Html.DisplayFor(modelItem => item.Prize)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Track.Name)
-            </td>
-            <td>
-                <a asp-action="Edit" asp-route-id="@item.Id">Edit</a> |
-                <a asp-action="Details" asp-route-id="@item.Id">Details</a> |
-                <a asp-action="Delete" asp-route-id="@item.Id">Delete</a>
-            </td>
-        </tr>
-}
     </tbody>
 </table>

--- a/FairWeatherFriend/Views/Races/Index.cshtml
+++ b/FairWeatherFriend/Views/Races/Index.cshtml
@@ -13,6 +13,12 @@
     <thead>
         <tr>
             <th>
+                @Html.DisplayNameFor(model => model.Name)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Laps)
+            </th>
+            <th>
                 @Html.DisplayNameFor(model => model.TimeOfDay)
             </th>
             <th>
@@ -31,22 +37,28 @@
 @foreach (var item in Model) {
         <tr>
             <td>
+                @Html.DisplayFor(modelItem => item.Name)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Laps)
+            </td>
+            <td>
                 @Html.DisplayFor(modelItem => item.TimeOfDay)
             </td>
             <td>@Html.DisplayFor(modelItem => item.isCancelled)</td>
             @*@if (item.isCancelled == true)
-            {
+        {
 
-                <dd class="col-sm-10">
-                    Cancelled
-                </dd>
-            }
-            else
-            {
-                <dd class="col-sm-10">
-                    Race still on
-                </dd>
-            }*@
+            <dd class="col-sm-10">
+                Cancelled
+            </dd>
+        }
+        else
+        {
+            <dd class="col-sm-10">
+                Race still on
+            </dd>
+        }*@
             <td>
                 @Html.DisplayFor(modelItem => item.Prize)
             </td>

--- a/FairWeatherFriend/Views/Shared/_Layout.cshtml
+++ b/FairWeatherFriend/Views/Shared/_Layout.cshtml
@@ -21,7 +21,7 @@
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
             <div class="container">
-                <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">FairWeatherFriend</a>
+                <a class="navbar-brand" asp-area="" asp-controller="RaceTracks" asp-action="Index">Fair Weather Friend</a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
@@ -30,10 +30,10 @@
                     <partial name="_LoginPartial" />
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="RaceTracks" asp-action="Index">Race Tracks</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Races" asp-action="Index">Races</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
Nav bar now has links for the racetrack index and race index.
Race tracks now have an index view displaying the track's name, location, and zip code.
The create new button and edit buttons on the index and details view should only be accessible by an admin account.
The details view of the race tracks page should display the track's name, location, zip code, and a list of upcoming races with their date, prize, name, and whether they have been cancelled.
Race model, create view, and details view should be updated with the race name and number of laps.
Only admins should be able to create or edit racetracks or races, or delete races.