### PR TITLE
Race index search bar/past races

### DIFF
--- a/FairWeatherFriend/Controllers/RaceTracksController.cs
+++ b/FairWeatherFriend/Controllers/RaceTracksController.cs
@@ -35,6 +35,9 @@ namespace FairWeatherFriend.Controllers
 
             var raceTrack = await _context.RaceTrack.Include(r => r.Races)
                 .FirstOrDefaultAsync(m => m.Id == id);
+
+
+
             if (raceTrack == null)
             {
                 return NotFound();

--- a/FairWeatherFriend/Controllers/RacesController.cs
+++ b/FairWeatherFriend/Controllers/RacesController.cs
@@ -20,9 +20,36 @@ namespace FairWeatherFriend.Controllers
         }
 
         // GET: Races
-        public async Task<IActionResult> Index()
+        public async Task<IActionResult> Index(string searchQuery)
         {
-            var applicationDbContext = _context.Race.Include(r => r.Track);
+            DateTime currentDate = DateTime.Now;
+            var applicationDbContext = _context.Race.Include(r => r.Track).Where(r => DateTime.Compare(r.TimeOfDay, currentDate) > 0);
+
+            if(searchQuery != null)
+            {
+                string normalizedSearchQuery = searchQuery.ToLower();
+                applicationDbContext = applicationDbContext.Where(r => r.Track.Name.ToLower().Contains(normalizedSearchQuery));
+                
+            }
+
+            applicationDbContext = applicationDbContext.OrderBy(r => r.TimeOfDay);
+            return View(await applicationDbContext.ToListAsync());
+
+
+        }
+
+        public async Task<IActionResult> PastRaces(string searchQuery)
+        {
+            DateTime currentDate = DateTime.Now;
+            var applicationDbContext = _context.Race.Include(r => r.Track).Where(r => DateTime.Compare(r.TimeOfDay, currentDate) < 0);
+            if (searchQuery != null)
+            {
+                string normalizedSearchQuery = searchQuery.ToLower();
+                applicationDbContext = applicationDbContext.Where(r => r.Track.Name.ToLower().Contains(normalizedSearchQuery));
+
+            } 
+
+            applicationDbContext = applicationDbContext.OrderByDescending(r => r.TimeOfDay);
             return View(await applicationDbContext.ToListAsync());
         }
 

--- a/FairWeatherFriend/Controllers/RacesController.cs
+++ b/FairWeatherFriend/Controllers/RacesController.cs
@@ -75,7 +75,7 @@ namespace FairWeatherFriend.Controllers
         // GET: Races/Create
         public IActionResult Create()
         {
-            ViewData["RaceTrackId"] = new SelectList(_context.RaceTrack, "Id", "Location");
+            ViewData["RaceTrackId"] = new SelectList(_context.RaceTrack, "Id", "Name");
             return View();
         }
 

--- a/FairWeatherFriend/Views/RaceTracks/Details.cshtml
+++ b/FairWeatherFriend/Views/RaceTracks/Details.cshtml
@@ -40,32 +40,36 @@
 <div>
     <dl>
         <h5>Upcoming Races</h5>
-        @foreach (Race UpcomingRace in Model.Races)
+        @foreach (Race UpcomingRace in Model.Races.OrderBy(r => r.TimeOfDay))
         {
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(ModelItem => UpcomingRace.Name)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(ModelItem => UpcomingRace.Name)
-            </dd>
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(ModelItem => UpcomingRace.TimeOfDay)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(ModelItem => UpcomingRace.TimeOfDay)
-            </dd>
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(ModelItem => UpcomingRace.Prize)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(ModelItem => UpcomingRace.Prize)
-            </dd>
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(ModelItem => UpcomingRace.isCancelled)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(ModelItem => UpcomingRace.isCancelled)
-            </dd>
+            @if (DateTime.Compare(UpcomingRace.TimeOfDay, DateTime.Now) > 0)
+            {
+                <dt class="col-sm-2">
+                    @Html.DisplayNameFor(ModelItem => UpcomingRace.Name)
+                </dt>
+                <dd class="col-sm-10">
+                    @Html.DisplayFor(ModelItem => UpcomingRace.Name)
+                </dd>
+                <dt class="col-sm-2">
+                    @Html.DisplayNameFor(ModelItem => UpcomingRace.TimeOfDay)
+                </dt>
+                <dd class="col-sm-10">
+                    @Html.DisplayFor(ModelItem => UpcomingRace.TimeOfDay)
+                </dd>
+                <dt class="col-sm-2">
+                    @Html.DisplayNameFor(ModelItem => UpcomingRace.Prize)
+                </dt>
+                <dd class="col-sm-10">
+                    @Html.DisplayFor(ModelItem => UpcomingRace.Prize)
+                </dd>
+                <dt class="col-sm-2">
+                    @Html.DisplayNameFor(ModelItem => UpcomingRace.isCancelled)
+                </dt>
+                <dd class="col-sm-10">
+                    @Html.DisplayFor(ModelItem => UpcomingRace.isCancelled)
+                </dd>
+            }
+
         }
     </dl>
 </div>

--- a/FairWeatherFriend/Views/Races/Create.cshtml
+++ b/FairWeatherFriend/Views/Races/Create.cshtml
@@ -38,7 +38,7 @@
                 <span asp-validation-for="Prize" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="RaceTrackId" class="control-label"></label>
+                <label asp-for="Track.Name" class="control-label"></label>
                 <select asp-for="RaceTrackId" class="form-control" asp-items="ViewBag.RaceTrackId"></select>
             </div>
             <div class="form-group">

--- a/FairWeatherFriend/Views/Races/Index.cshtml
+++ b/FairWeatherFriend/Views/Races/Index.cshtml
@@ -50,16 +50,25 @@
         @foreach (var item in Model)
         {
         <tr>
-            <td>
+            @if(item.isCancelled == true)
+            {
+            <td class="Cancelled">
                 @Html.DisplayFor(modelItem => item.Name)
             </td>
+            } else
+            {
+        <td>
+                @Html.DisplayFor(modelItem => item.Name)
+        </td>
+            }
+
+            
             <td>
                 @Html.DisplayFor(modelItem => item.Laps)
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.TimeOfDay)
             </td>
-            @*<td>@Html.DisplayFor(modelItem => item.isCancelled)</td>*@
             <td>
                 @Html.DisplayFor(modelItem => item.Prize)
             </td>
@@ -69,7 +78,7 @@
             @if (item.isCancelled == true)
             {
 
-                <td>
+                <td class="Cancelled">
                     Cancelled
                 </td>
             }

--- a/FairWeatherFriend/Views/Races/Index.cshtml
+++ b/FairWeatherFriend/Views/Races/Index.cshtml
@@ -36,67 +36,66 @@
                 @Html.DisplayNameFor(model => model.TimeOfDay)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.isCancelled)
-            </th>
-            <th>
                 @Html.DisplayNameFor(model => model.Prize)
             </th>
             <th>
                 @Html.DisplayNameFor(model => model.Track)
             </th>
-            <th></th>
+            <th>
+                Status
+            </th>
         </tr>
     </thead>
     <tbody>
         @foreach (var item in Model)
         {
-            <tr>
-                <td>
-                    @Html.DisplayFor(modelItem => item.Name)
-                </td>
-                <td>
-                    @Html.DisplayFor(modelItem => item.Laps)
-                </td>
-                <td>
-                    @Html.DisplayFor(modelItem => item.TimeOfDay)
-                </td>
-                <td>@Html.DisplayFor(modelItem => item.isCancelled)</td>
-                @*@if (item.isCancelled == true)
-                    {
+        <tr>
+            <td>
+                @Html.DisplayFor(modelItem => item.Name)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Laps)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.TimeOfDay)
+            </td>
+            @*<td>@Html.DisplayFor(modelItem => item.isCancelled)</td>*@
+            <td>
+                @Html.DisplayFor(modelItem => item.Prize)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Track.Name)
+            </td>
+            @if (item.isCancelled == true)
+            {
 
-                        <dd class="col-sm-10">
-                            Cancelled
-                        </dd>
-                    }
-                    else
-                    {
-                        <dd class="col-sm-10">
-                            Race still on
-                        </dd>
-                    }*@
                 <td>
-                    @Html.DisplayFor(modelItem => item.Prize)
+                    Cancelled
                 </td>
+            }
+            else
+            {
                 <td>
-                    @Html.DisplayFor(modelItem => item.Track.Name)
+                    Race still on
                 </td>
-                <td>
-                    @if (SignInManager.IsSignedIn(User) && @UserManager.GetUserAsync(User).Result.isAdmin == true)
-                    {
-                        <a asp-action="Edit" asp-route-id="@item.Id">Edit</a>
-
-
-                    }
-                    @if (SignInManager.IsSignedIn(User) && @UserManager.GetUserAsync(User).Result.isAdmin == true)
-                    {
-                        <a asp-action="Delete" asp-route-id="@item.Id">Delete</a>
-                    }
+            }
+            <td>
+                @if (SignInManager.IsSignedIn(User) && @UserManager.GetUserAsync(User).Result.isAdmin == true)
+                {
+                    <a asp-action="Edit" asp-route-id="@item.Id">Edit</a>
 
 
+                }
+                @if (SignInManager.IsSignedIn(User) && @UserManager.GetUserAsync(User).Result.isAdmin == true)
+                {
+                    <a asp-action="Delete" asp-route-id="@item.Id">Delete</a>
+                }
 
-                    <a asp-action="Details" asp-route-id="@item.Id">Details</a> 
-                </td>
-            </tr>
+
+
+                <a asp-action="Details" asp-route-id="@item.Id">Details</a>
+            </td>
+        </tr>
         }
     </tbody>
 </table>

--- a/FairWeatherFriend/Views/Races/Index.cshtml
+++ b/FairWeatherFriend/Views/Races/Index.cshtml
@@ -18,6 +18,11 @@
         <a asp-action="Create">Create New</a>
     </p>
 }
+
+<form>
+    <input type="text" name="searchQuery" />
+    <button type="submit">Search by Track Name</button>
+</form>
 <table class="table">
     <thead>
         <tr>
@@ -95,3 +100,5 @@
         }
     </tbody>
 </table>
+
+<a asp-action="PastRaces">View Past Races</a>

--- a/FairWeatherFriend/Views/Races/PastRaces.cshtml
+++ b/FairWeatherFriend/Views/Races/PastRaces.cshtml
@@ -17,12 +17,6 @@
                 @Html.DisplayNameFor(model => model.TimeOfDay)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.DateOnly)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.isCancelled)
-            </th>
-            <th>
                 @Html.DisplayNameFor(model => model.Prize)
             </th>
             <th>
@@ -34,7 +28,9 @@
             <th>
                 @Html.DisplayNameFor(model => model.Track)
             </th>
-            <th></th>
+            <th>
+                Status
+            </th>
         </tr>
     </thead>
     <tbody>
@@ -42,12 +38,6 @@
         <tr>
             <td>
                 @Html.DisplayFor(modelItem => item.TimeOfDay)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.DateOnly)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.isCancelled)
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.Prize)
@@ -61,6 +51,19 @@
             <td>
                 @Html.DisplayFor(modelItem => item.Track.Name)
             </td>
+            @if (item.isCancelled == true)
+            {
+
+                <td>
+                    Cancelled
+                </td>
+            }
+            else
+            {
+                <td>
+                    Race still on
+                </td>
+            }
             <td>
 
                 <a asp-action="Details" asp-route-id="@item.Id">Details</a> |

--- a/FairWeatherFriend/Views/Races/PastRaces.cshtml
+++ b/FairWeatherFriend/Views/Races/PastRaces.cshtml
@@ -1,0 +1,76 @@
+﻿@model IEnumerable<FairWeatherFriend.Models.Race>
+
+@{
+    ViewData["Title"] = "PastRaces";
+}
+
+<h1>Past Races</h1>
+
+<form>
+    <input type="text" name="searchQuery" />
+    <button type="submit">Search by Track Name</button>
+</form>
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                @Html.DisplayNameFor(model => model.TimeOfDay)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.DateOnly)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.isCancelled)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Prize)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Name)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Laps)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Track)
+            </th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model) {
+        <tr>
+            <td>
+                @Html.DisplayFor(modelItem => item.TimeOfDay)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.DateOnly)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.isCancelled)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Prize)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Name)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Laps)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Track.Name)
+            </td>
+            <td>
+
+                <a asp-action="Details" asp-route-id="@item.Id">Details</a> |
+
+            </td>
+        </tr>
+}
+    </tbody>
+</table>
+
+<a asp-action="Index">View Upcoming Races</a>
+
+

--- a/FairWeatherFriend/Views/Races/PastRaces.cshtml
+++ b/FairWeatherFriend/Views/Races/PastRaces.cshtml
@@ -14,16 +14,16 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.TimeOfDay)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Prize)
-            </th>
-            <th>
                 @Html.DisplayNameFor(model => model.Name)
             </th>
             <th>
                 @Html.DisplayNameFor(model => model.Laps)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.TimeOfDay)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Prize)
             </th>
             <th>
                 @Html.DisplayNameFor(model => model.Track)
@@ -34,43 +34,55 @@
         </tr>
     </thead>
     <tbody>
-@foreach (var item in Model) {
-        <tr>
-            <td>
-                @Html.DisplayFor(modelItem => item.TimeOfDay)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Prize)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Name)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Laps)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Track.Name)
-            </td>
-            @if (item.isCancelled == true)
-            {
+        @foreach (var item in Model)
+        {
+            <tr>
+                @if (item.isCancelled == true)
+                {
+                    <td class="Cancelled">
+                        @Html.DisplayFor(modelItem => item.Name)
+                    </td>
+                }
+                else
+                {
+                    <td>
+                        @Html.DisplayFor(modelItem => item.Name)
+                    </td>
+                }
+
 
                 <td>
-                    Cancelled
+                    @Html.DisplayFor(modelItem => item.Laps)
                 </td>
-            }
-            else
-            {
                 <td>
-                    Race still on
+                    @Html.DisplayFor(modelItem => item.TimeOfDay)
                 </td>
-            }
-            <td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Prize)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Track.Name)
+                </td>
+                @if (item.isCancelled == true)
+                {
 
-                <a asp-action="Details" asp-route-id="@item.Id">Details</a> |
+                    <td class="Cancelled">
+                        Cancelled
+                    </td>
+                }
+                else
+                {
+                    <td>
+                        Race Complete
+                    </td>
+                }
+                <td>
 
-            </td>
-        </tr>
-}
+                    <a asp-action="Details" asp-route-id="@item.Id">Details</a> |
+
+                </td>
+            </tr>
+        }
     </tbody>
 </table>
 


### PR DESCRIPTION
Races are now split up into an upcoming races view and a past races view. Upcoming races are sorted by date, nearest to latest, and past races are sorted by most recent. 
Upcoming and past race views both have a search bar so the user can filter races by track name. 
Index and past views now display race status. Cancelled races now have a red background for the race name and the cancelled field.
Create race view now shows race tracks names instead of ids.

-Pull down the branch sb-races-index and run the server. Log in with the username admin@admin.com and the password Admin8*. 
-Navigate to the race index page by clicking the "Races" link in the nav bar. Use the "Create New" link to add a new race to the database. The dropdown for racetrack should be labelled "Race Track Name" and the dropdown itself should display names of all entered race tracks.
-Add multiple races from each race track. Make sure to mark some of them as cancelled.
-When you go back to the index view, you should see the list of races ordered by date. In the search bar, type a string contained in the name of a racetrack and hit "Submit". You should now only see results that match that string.
-Navigate to the "Past Races" view via the link at the bottom left. Races should be ordered descending by date. Test the search functionality the same way as the index page.
-Cancelled races should have their name and status highlighted in red, and a text of "Cancelled".